### PR TITLE
Implement padel scoring on Wear OS app

### DIFF
--- a/app/src/main/java/com/example/watch/presentation/MainActivity.kt
+++ b/app/src/main/java/com/example/watch/presentation/MainActivity.kt
@@ -1,72 +1,122 @@
-/* While this template provides a good starting point for using Wear Compose, you can always
- * take a look at https://github.com/android/wear-os-samples/tree/main/ComposeStarter to find the
- * most up to date changes to the libraries and their usages.
- */
-
 package com.example.watch.presentation
 
 import android.os.Bundle
+import android.view.KeyEvent
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
-import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
 import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.wear.compose.material.Button
+import androidx.wear.compose.material.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
 import androidx.wear.compose.material.MaterialTheme
-import androidx.wear.compose.material.Text
 import androidx.wear.compose.material.TimeText
 import androidx.wear.tooling.preview.devices.WearDevices
 import com.example.watch.R
 import com.example.watch.presentation.theme.WatchTheme
 
 class MainActivity : ComponentActivity() {
+    private var scoreState by mutableStateOf(ScoreState())
+    private val history = mutableListOf<ScoreState>()
+
     override fun onCreate(savedInstanceState: Bundle?) {
-        installSplashScreen()
-
         super.onCreate(savedInstanceState)
+        setContent { ScoreApp(scoreState, onUndo = { undo() }) }
+    }
 
-        setTheme(android.R.style.Theme_DeviceDefault)
+    override fun onKeyDown(keyCode: Int, event: KeyEvent?): Boolean {
+        return when (keyCode) {
+            KeyEvent.KEYCODE_STEM_PRIMARY, KeyEvent.KEYCODE_STEM_1 -> {
+                addPointA(); true
+            }
+            KeyEvent.KEYCODE_STEM_2 -> {
+                addPointB(); true
+            }
+            else -> super.onKeyDown(keyCode, event)
+        }
+    }
 
-        setContent {
-            WearApp("Android")
+    private fun addPointA() {
+        history.add(scoreState)
+        scoreState = scoreState.addPointToA()
+    }
+
+    private fun addPointB() {
+        history.add(scoreState)
+        scoreState = scoreState.addPointToB()
+    }
+
+    private fun undo() {
+        if (history.isNotEmpty()) {
+            scoreState = history.removeLast()
         }
     }
 }
 
 @Composable
-fun WearApp(greetingName: String) {
+fun ScoreApp(score: ScoreState, onUndo: () -> Unit) {
     WatchTheme {
-        Box(
-            modifier = Modifier
-                .fillMaxSize()
-                .background(MaterialTheme.colors.background),
-            contentAlignment = Alignment.Center
-        ) {
+        ScoreScreen(score = score, onUndo = onUndo)
+    }
+}
+
+@Composable
+fun ScoreScreen(score: ScoreState, onUndo: () -> Unit) {
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(MaterialTheme.colors.background)
+            .padding(8.dp),
+        contentAlignment = Alignment.Center
+    ) {
+        Column(horizontalAlignment = Alignment.CenterHorizontally) {
             TimeText()
-            Greeting(greetingName = greetingName)
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceEvenly
+            ) {
+                TeamScore(name = stringResource(R.string.team_a),
+                    sets = score.setsA,
+                    games = score.gamesA,
+                    points = score.pointsA)
+                TeamScore(name = stringResource(R.string.team_b),
+                    sets = score.setsB,
+                    games = score.gamesB,
+                    points = score.pointsB)
+            }
+            Button(onClick = onUndo) {
+                Text(stringResource(R.string.undo))
+            }
         }
     }
 }
 
 @Composable
-fun Greeting(greetingName: String) {
-    Text(
-        modifier = Modifier.fillMaxWidth(),
-        textAlign = TextAlign.Center,
-        color = MaterialTheme.colors.primary,
-        text = stringResource(R.string.hello_world, greetingName)
-    )
+fun TeamScore(name: String, sets: Int, games: Int, points: Int) {
+    Column(horizontalAlignment = Alignment.CenterHorizontally) {
+        Text(name)
+        Text(stringResource(R.string.sets) + " $sets")
+        Text(stringResource(R.string.games) + " $games")
+        Text(stringResource(R.string.points) + " ${pointsToString(points)}")
+    }
 }
 
 @Preview(device = WearDevices.SMALL_ROUND, showSystemUi = true)
 @Composable
 fun DefaultPreview() {
-    WearApp("Preview Android")
+    ScoreApp(ScoreState(), onUndo = {})
 }

--- a/app/src/main/java/com/example/watch/presentation/ScoreState.kt
+++ b/app/src/main/java/com/example/watch/presentation/ScoreState.kt
@@ -1,0 +1,63 @@
+package com.example.watch.presentation
+
+/**
+ * Represents the score for a padel match.
+ */
+data class ScoreState(
+    val pointsA: Int = 0,
+    val pointsB: Int = 0,
+    val gamesA: Int = 0,
+    val gamesB: Int = 0,
+    val setsA: Int = 0,
+    val setsB: Int = 0
+) {
+    fun addPointToA(): ScoreState {
+        var pA = pointsA + 1
+        var pB = pointsB
+        var gA = gamesA
+        var gB = gamesB
+        var sA = setsA
+        var sB = setsB
+
+        if (pA >= 4 && pA - pB >= 2) {
+            gA++
+            pA = 0
+            pB = 0
+            if (gA >= 6 && gA - gB >= 2) {
+                sA++
+                gA = 0
+                gB = 0
+            }
+        }
+        return copy(pointsA = pA, pointsB = pB, gamesA = gA, gamesB = gB, setsA = sA, setsB = sB)
+    }
+
+    fun addPointToB(): ScoreState {
+        var pA = pointsA
+        var pB = pointsB + 1
+        var gA = gamesA
+        var gB = gamesB
+        var sA = setsA
+        var sB = setsB
+
+        if (pB >= 4 && pB - pA >= 2) {
+            gB++
+            pA = 0
+            pB = 0
+            if (gB >= 6 && gB - gA >= 2) {
+                sB++
+                gA = 0
+                gB = 0
+            }
+        }
+        return copy(pointsA = pA, pointsB = pB, gamesA = gA, gamesB = gB, setsA = sA, setsB = sB)
+    }
+}
+
+fun pointsToString(points: Int): String = when (points) {
+    0 -> "0"
+    1 -> "15"
+    2 -> "30"
+    3 -> "40"
+    else -> "A"
+}

--- a/app/src/main/res/values-round/strings.xml
+++ b/app/src/main/res/values-round/strings.xml
@@ -1,3 +1,9 @@
 <resources>
     <string name="hello_world">From the Round world,\nHello, %1$s!</string>
+    <string name="team_a">Team A</string>
+    <string name="team_b">Team B</string>
+    <string name="undo">Undo</string>
+    <string name="sets">Sets:</string>
+    <string name="games">Games:</string>
+    <string name="points">Points:</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -5,4 +5,10 @@
     values-round/strings.xml for round devices.
     -->
     <string name="hello_world">From the Square world,\nHello, %1$s!</string>
+    <string name="team_a">Team A</string>
+    <string name="team_b">Team B</string>
+    <string name="undo">Undo</string>
+    <string name="sets">Sets:</string>
+    <string name="games">Games:</string>
+    <string name="points">Points:</string>
 </resources>


### PR DESCRIPTION
## Summary
- create `ScoreState` to hold match scores
- build padel scoreboard UI in `MainActivity`
- support undo button and hardware key scoring
- add strings for team labels and UI text

## Testing
- `./gradlew assembleDebug` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68723ff332b88330a720b74cd1691b18